### PR TITLE
chore!: depend on `@comapeo/schema` instead of legacy `@mapeo/schema`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mapeo Mock Data
 
-Module and CLI to generate fake data for Mapeo
+Module and CLI to generate fake data for CoMapeo
 
 ## Installation
 
@@ -37,7 +37,7 @@ example output:
 
 #### `generate-mapeo-data`
 
-Generates JSON-formatted Mapeo data based on [`@mapeo/schema`](https://github.com/digidem/mapeo-schema/).
+Generates JSON-formatted Mapeo data based on [`@comapeo/schema`](https://github.com/digidem/comapeo-schema/).
 
 - `--schema, -s`: specifies the schema to generate data for. Use the `list-mapeo-schemas` command to learn which ones are available.
 - `--version, -v`: (_optional_) specifies the schema version to use for `--schema`. Uses latest version by default.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { docSchemas } from '@mapeo/schema'
+import { docSchemas } from '@comapeo/schema'
 import { JSONSchemaFaker, createFakerSchema } from './lib/faker.js'
 import { extractSchemaVersion, isValidSchemaName } from './lib/schema.js'
 
@@ -14,10 +14,10 @@ export function listSchemas() {
 }
 
 /**
- * @template {import('@mapeo/schema/dist/types.js').SchemaName} TSchemaName
+ * @template {import('@comapeo/schema/dist/types.js').SchemaName} TSchemaName
  * @param {TSchemaName} schemaName
  * @param {{version?: string, count?: number}} [options]
- * @returns {Array<Extract<import('@mapeo/schema').MapeoDoc, { schemaName: TSchemaName }>>}
+ * @returns {Array<Extract<import('@comapeo/schema').MapeoDoc, { schemaName: TSchemaName }>>}
  */
 export function generate(schemaName, { count } = {}) {
   isValidSchemaName(schemaName)
@@ -25,12 +25,12 @@ export function generate(schemaName, { count } = {}) {
   const targetSchema = docSchemas[schemaName]
   const numberToGenerate = count || 1
 
-  /** @type {Array<Extract<import('@mapeo/schema').MapeoDoc, { schemaName: TSchemaName }>>} */
+  /** @type {Array<Extract<import('@comapeo/schema').MapeoDoc, { schemaName: TSchemaName }>>} */
   const result = []
 
   for (let i = 0; i < numberToGenerate; i++) {
     result.push(
-      /** @type {Extract<import('@mapeo/schema').MapeoDoc, { schemaName: TSchemaName }>} */ (
+      /** @type {Extract<import('@comapeo/schema').MapeoDoc, { schemaName: TSchemaName }>} */ (
         JSONSchemaFaker.generate(createFakerSchema(targetSchema))
       ),
     )

--- a/lib/faker.js
+++ b/lib/faker.js
@@ -2,7 +2,7 @@ import { JSONSchemaFaker } from 'json-schema-faker'
 import { faker } from '@faker-js/faker'
 
 /**
- * @typedef {typeof import('@mapeo/schema').docSchemas[import('@mapeo/schema/dist/types.js').SchemaName]} ValidSchema
+ * @typedef {typeof import('@comapeo/schema').docSchemas[import('@comapeo/schema/dist/types.js').SchemaName]} ValidSchema
  */
 
 /**

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,4 +1,4 @@
-import { docSchemas } from '@mapeo/schema'
+import { docSchemas } from '@comapeo/schema'
 
 /**
  * @param {string} jsonSchemaId
@@ -13,7 +13,7 @@ export function extractSchemaVersion(jsonSchemaId) {
  *
  * @param {string} name
  *
- * @return {asserts name is import('@mapeo/schema/dist/types.js').SchemaName}
+ * @return {asserts name is import('@comapeo/schema/dist/types.js').SchemaName}
  */
 export function isValidSchemaName(name) {
   if (!(name in docSchemas)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@mapeo/schema": "^3.0.0-next.28"
+        "@comapeo/schema": "^1.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -37,6 +37,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@comapeo/schema": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.0.0.tgz",
+      "integrity": "sha512-dK227I+0yg9D2y5/O5NGywx50tgeNYyUkl1uYnSmNAPlbv+r2KX9aaC9m4dEjIja2aR2VFnYn6z537ERZiahqQ==",
+      "peer": true,
+      "dependencies": {
+        "compact-encoding": "^2.12.0",
+        "protobufjs": "^7.2.5",
+        "type-fest": "^4.26.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -204,40 +215,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
-    },
-    "node_modules/@mapeo/schema": {
-      "version": "3.0.0-next.28",
-      "resolved": "https://registry.npmjs.org/@mapeo/schema/-/schema-3.0.0-next.28.tgz",
-      "integrity": "sha512-yiAaSgJAg9yR3E5YKfkDpE3bChlUmwIdqI+/x8Ly7RYZJ75EHMHA7yBUqSNUYwyPZ0xym6bXZ60Z0T4V41v58g==",
-      "peer": true,
-      "dependencies": {
-        "ajv": "^8.12.0",
-        "compact-encoding": "^2.12.0",
-        "protobufjs": "^7.2.5",
-        "type-fest": "^4.26.0"
-      }
-    },
-    "node_modules/@mapeo/schema/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@mapeo/schema/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "peer": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -934,7 +911,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -947,12 +925,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "node_modules/fast-uri": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
-      "peer": true
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -1698,15 +1670,6 @@
         }
       ]
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2136,6 +2099,17 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
     },
+    "@comapeo/schema": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.0.0.tgz",
+      "integrity": "sha512-dK227I+0yg9D2y5/O5NGywx50tgeNYyUkl1uYnSmNAPlbv+r2KX9aaC9m4dEjIja2aR2VFnYn6z537ERZiahqQ==",
+      "peer": true,
+      "requires": {
+        "compact-encoding": "^2.12.0",
+        "protobufjs": "^7.2.5",
+        "type-fest": "^4.26.0"
+      }
+    },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2258,38 +2232,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
-    },
-    "@mapeo/schema": {
-      "version": "3.0.0-next.28",
-      "resolved": "https://registry.npmjs.org/@mapeo/schema/-/schema-3.0.0-next.28.tgz",
-      "integrity": "sha512-yiAaSgJAg9yR3E5YKfkDpE3bChlUmwIdqI+/x8Ly7RYZJ75EHMHA7yBUqSNUYwyPZ0xym6bXZ60Z0T4V41v58g==",
-      "peer": true,
-      "requires": {
-        "ajv": "^8.12.0",
-        "compact-encoding": "^2.12.0",
-        "protobufjs": "^7.2.5",
-        "type-fest": "^4.26.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "8.17.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-          "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-          "peer": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.3",
-            "fast-uri": "^3.0.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "peer": true
-        }
-      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2822,7 +2764,8 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2835,12 +2778,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "fast-uri": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
-      "peer": true
     },
     "fastq": {
       "version": "1.15.0",
@@ -3363,12 +3300,6 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
-    },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "peer": true
     },
     "resolve-from": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@mapeo/schema": "^3.0.0-next.28"
+    "@comapeo/schema": "^1.0.0"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
Now that `@comapeo/schema@1.0.0` is out, we can depend on that.
