### PR TITLE
chore: use `createRequire` for comapeo/geometry

### DIFF
--- a/lib/faker.js
+++ b/lib/faker.js
@@ -172,11 +172,9 @@ function createFakerSchema(schema) {
       return s
     }
     case 'RemoteDetectionAlert':
-      // @ts-ignore
-      s.properties.geometry = {
-        //$ref: Geometry.$id,
-        ...deref.dereferenceSync(Geometry),
-      }
+      // @ts-expect-error Dereferencing this causes a type error, but the data
+      // is generated correctly.
+      s.properties.geometry = deref.dereferenceSync(Geometry)
       return s
   }
 }

--- a/lib/faker.js
+++ b/lib/faker.js
@@ -1,13 +1,9 @@
 import { JSONSchemaFaker } from 'json-schema-faker'
 import { faker } from '@faker-js/faker'
 import deref from 'dereference-json-schema'
-import { readFile } from 'node:fs/promises'
-
-const geometryPath = new URL(
-  '../node_modules/@comapeo/geometry/json/geometry.json',
-  import.meta.url,
-).pathname
-const Geometry = JSON.parse(await readFile(geometryPath, 'utf-8'))
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
+const Geometry = require('@comapeo/geometry/json/geometry.json')
 
 /**
  * @typedef {typeof import('@comapeo/schema').docSchemas[import('@comapeo/schema/dist/types.js').SchemaName]} ValidSchema
@@ -176,8 +172,9 @@ function createFakerSchema(schema) {
       return s
     }
     case 'RemoteDetectionAlert':
+      // @ts-ignore
       s.properties.geometry = {
-        $ref: Geometry.$id,
+        //$ref: Geometry.$id,
         ...deref.dereferenceSync(Geometry),
       }
       return s

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "emitDeclarationOnly": true,
     "noFallthroughCasesInSwitch": true,
     "strictNullChecks": true,
-    "declarationDir": "./types"
+    "declarationDir": "./types",
+    "resolveJsonModule": true
   },
   "include": ["./index.js", "lib/**/*.js"],
   "exclude": ["bin"]


### PR DESCRIPTION
This fixes the import of geometry in core. Additionally I added the `resolveJsonModule` flag in `tsconfig.json`