### PR TITLE
test: test that all generated values can be encoded

### DIFF
--- a/lib/faker.js
+++ b/lib/faker.js
@@ -143,12 +143,7 @@ function createFakerSchema(schema) {
       return s
     }
     case 'Icon': {
-      s.properties.variants.items.oneOf.forEach((variant) =>
-        mutateWithFakerProperty(
-          variant.properties.blobVersionId,
-          'mapeo.versionId',
-        ),
-      )
+      mutateWithFakerProperty(s.definitions.blobVersionId, 'mapeo.versionId')
       return s
     }
     case 'Track': {

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -1,0 +1,29 @@
+import { encode } from '@comapeo/schema'
+import test from 'node:test'
+import { generate, listSchemas } from '../index.js'
+
+test('generates encodable data', { concurrency: true }, async (t) => {
+  const COUNT = 1000
+
+  const schemaNames = Object.keys(listSchemas())
+
+  for (const schemaName of schemaNames) {
+    if (schemaName === 'coreOwnership') continue
+    await t.test(schemaName, () => {
+      for (const doc of generate(schemaName, { count: COUNT })) {
+        // This should not throw.
+        encode(doc)
+      }
+    })
+  }
+
+  await t.test('coreOwnership', () => {
+    for (const doc of generate('coreOwnership', { count: COUNT })) {
+      // This should not throw.
+      encode({
+        ...doc,
+        identitySignature: Buffer.alloc(32),
+      })
+    }
+  })
+})


### PR DESCRIPTION
After running this test I also noticed an issue with icons, where (inexplicably) the `blobVersionId` would sometimes be a regular string, not a version ID. I was able to fix this by changing the definition.

I think this is a useful change on its own, but it will make future changes (such as upgrading some dependencies) much easier.