### PR TITLE
test: assert that generated data is valid

### DIFF
--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -1,8 +1,9 @@
-import { encode } from '@comapeo/schema'
+import { encode, validate, valueOf } from '@comapeo/schema'
+import assert from 'node:assert/strict'
 import test from 'node:test'
 import { generate, listSchemas } from '../index.js'
 
-test('generates encodable data', { concurrency: true }, async (t) => {
+test('generates valid data', { concurrency: true }, async (t) => {
   const COUNT = 1000
 
   const schemaNames = Object.keys(listSchemas())
@@ -11,6 +12,7 @@ test('generates encodable data', { concurrency: true }, async (t) => {
     if (schemaName === 'coreOwnership') continue
     await t.test(schemaName, () => {
       for (const doc of generate(schemaName, { count: COUNT })) {
+        assert(validate(schemaName, valueOf(doc)), 'doc is valid')
         // This should not throw.
         encode(doc)
       }
@@ -19,6 +21,7 @@ test('generates encodable data', { concurrency: true }, async (t) => {
 
   await t.test('coreOwnership', () => {
     for (const doc of generate('coreOwnership', { count: COUNT })) {
+      assert(validate('coreOwnership', doc), 'doc is valid')
       // This should not throw.
       encode({
         ...doc,


### PR DESCRIPTION
This beefs up our tests for `generate` by making sure that they pass `@comapeo/schema`'s `validate` function.

I thought there was a bug here, so I wrote this test. There wasn't a bug, but I still think this test is useful. Feel free to close if you disagree.