### PR TITLE
fix: generate valid URLs for self-hosted servers

### DIFF
--- a/lib/faker.js
+++ b/lib/faker.js
@@ -38,6 +38,7 @@ const FAKER_EXTENSIONS = /** @type {const} */ ({
     id8: () => hexString(8),
     comver: () =>
       `${Math.floor(Math.random() * 100)}.${Math.floor(Math.random() * 100)}`,
+    url: () => faker.internet.url(),
   },
 })
 
@@ -70,6 +71,10 @@ function createFakerSchema(schema) {
       return s
     }
     case 'DeviceInfo': {
+      mutateWithFakerProperty(
+        s.properties.selfHostedServerDetails.properties.baseUrl,
+        'mapeo.url',
+      )
       return s
     }
     case 'Field': {


### PR DESCRIPTION
The `DeviceInfo` property, `selfHostedServerDetails.baseUrl`, was being generated as a random string. Instead, it should be a valid URL.