### PR TITLE
chore: use @comapeo/schema@1.5.0 as dev dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "list-mapeo-schemas": "bin/list-mapeo-schemas.js"
       },
       "devDependencies": {
+        "@comapeo/schema": "^1.5.0",
         "@tsconfig/node20": "^20.1.2",
         "@types/node": "^20.9.1",
         "eslint": "^8.53.0",
@@ -29,7 +30,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@comapeo/schema": "^1.5.0"
+        "@comapeo/schema": "^1.4.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -45,7 +46,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@comapeo/geometry/-/geometry-1.1.1.tgz",
       "integrity": "sha512-MKnyzqhmpUUV5qCjUUDwUjuBx/ym9aizfOZ0h9+6SjQwCQa2kBRTN+Y9qDqteFSlJd0QMQRKpBmu+2OXJPypCQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "protobufjs": "^7.4.0"
       }
@@ -54,7 +55,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.5.0.tgz",
       "integrity": "sha512-MIT9BSo34ffUKn6kZuBf10Xs3/7FZ2tVwXLi+Oi5DiOuTEI1r03DAI9XzGTqU2FsnPkza+dc5h6aaBB/ZuOsrA==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@comapeo/geometry": "^1.1.1",
         "compact-encoding": "^2.12.0",
@@ -248,31 +249,31 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -282,31 +283,31 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@tsconfig/node20": {
       "version": "20.1.2",
@@ -318,6 +319,7 @@
       "version": "20.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.1.tgz",
       "integrity": "sha512-HhmzZh5LSJNS5O8jQKpJ/3ZcrrlG6L70hpGqMIAoM9YVD0YBRNWYsfwcXq8VnSjlNpCpgLzMXdiPo+dxcvSmiA==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -431,7 +433,7 @@
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
       "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==",
-      "peer": true
+      "dev": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -557,7 +559,7 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-2.12.0.tgz",
       "integrity": "sha512-8eCZLmyBT4LtC90F/ekIqWos8Y7NaFxY75qa/SlSDVa95NVgMcibQb8z8MTeKb9zctemOJczSXMf5pwMqKjYEQ==",
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "b4a": "^1.3.0"
       }
@@ -1399,7 +1401,7 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.4.tgz",
       "integrity": "sha512-qtzLbJE8hq7VabR3mISmVGtoXP8KGc2Z/AT8OuqlYD7JTR3oqrgwdjnk07wpj1twXxYmgDXgoKVWUG/fReSzHg==",
-      "peer": true
+      "dev": true
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -1765,8 +1767,8 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
       "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "dev": true,
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2156,7 +2158,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -2250,7 +2253,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@comapeo/geometry/-/geometry-1.1.1.tgz",
       "integrity": "sha512-MKnyzqhmpUUV5qCjUUDwUjuBx/ym9aizfOZ0h9+6SjQwCQa2kBRTN+Y9qDqteFSlJd0QMQRKpBmu+2OXJPypCQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "protobufjs": "^7.4.0"
       }
@@ -2259,7 +2262,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.5.0.tgz",
       "integrity": "sha512-MIT9BSo34ffUKn6kZuBf10Xs3/7FZ2tVwXLi+Oi5DiOuTEI1r03DAI9XzGTqU2FsnPkza+dc5h6aaBB/ZuOsrA==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@comapeo/geometry": "^1.1.1",
         "compact-encoding": "^2.12.0",
@@ -2392,31 +2395,31 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -2426,31 +2429,31 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "peer": true
+      "dev": true
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
-      "peer": true
+      "dev": true
     },
     "@tsconfig/node20": {
       "version": "20.1.2",
@@ -2462,6 +2465,7 @@
       "version": "20.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.1.tgz",
       "integrity": "sha512-HhmzZh5LSJNS5O8jQKpJ/3ZcrrlG6L70hpGqMIAoM9YVD0YBRNWYsfwcXq8VnSjlNpCpgLzMXdiPo+dxcvSmiA==",
+      "dev": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -2541,7 +2545,7 @@
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
       "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==",
-      "peer": true
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -2635,7 +2639,7 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/compact-encoding/-/compact-encoding-2.12.0.tgz",
       "integrity": "sha512-8eCZLmyBT4LtC90F/ekIqWos8Y7NaFxY75qa/SlSDVa95NVgMcibQb8z8MTeKb9zctemOJczSXMf5pwMqKjYEQ==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "b4a": "^1.3.0"
       }
@@ -3248,7 +3252,7 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.4.tgz",
       "integrity": "sha512-qtzLbJE8hq7VabR3mISmVGtoXP8KGc2Z/AT8OuqlYD7JTR3oqrgwdjnk07wpj1twXxYmgDXgoKVWUG/fReSzHg==",
-      "peer": true
+      "dev": true
     },
     "memorystream": {
       "version": "0.3.1",
@@ -3492,7 +3496,7 @@
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
       "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "peer": true,
+      "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -3741,7 +3745,8 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@comapeo/schema": "^1.4.1"
+        "@comapeo/schema": "^1.5.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@comapeo/schema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.4.1.tgz",
-      "integrity": "sha512-Uh8kBluSWS8C9lI2tuM7emR1zPnCiMFKpY/0chUe3Peb92YSWzZ6iApHd5qRwljruamr99OBX35HVe8EnaPi+g==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.5.0.tgz",
+      "integrity": "sha512-MIT9BSo34ffUKn6kZuBf10Xs3/7FZ2tVwXLi+Oi5DiOuTEI1r03DAI9XzGTqU2FsnPkza+dc5h6aaBB/ZuOsrA==",
       "peer": true,
       "dependencies": {
         "@comapeo/geometry": "^1.1.1",
@@ -2256,9 +2256,9 @@
       }
     },
     "@comapeo/schema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.4.1.tgz",
-      "integrity": "sha512-Uh8kBluSWS8C9lI2tuM7emR1zPnCiMFKpY/0chUe3Peb92YSWzZ6iApHd5qRwljruamr99OBX35HVe8EnaPi+g==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.5.0.tgz",
+      "integrity": "sha512-MIT9BSo34ffUKn6kZuBf10Xs3/7FZ2tVwXLi+Oi5DiOuTEI1r03DAI9XzGTqU2FsnPkza+dc5h6aaBB/ZuOsrA==",
       "peer": true,
       "requires": {
         "@comapeo/geometry": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "type-fest": "^4.29.1"
   },
   "devDependencies": {
+    "@comapeo/schema": "^1.5.0",
     "@tsconfig/node20": "^20.1.2",
     "@types/node": "^20.9.1",
     "eslint": "^8.53.0",
@@ -47,7 +48,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@comapeo/schema": "^1.5.0"
+    "@comapeo/schema": "^1.4.1"
   },
   "prettier": {
     "semi": false,

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@comapeo/schema": "^1.4.1"
+    "@comapeo/schema": "^1.5.0"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
Specifies a specific version of schema as a dev dep. This allows us to test the latest compatible version without updating our peer dep requirements, which would be a breaking change.