### PR TITLE
feat!: update @comapeo/schema to 1.6.0 

### DIFF
--- a/lib/faker.js
+++ b/lib/faker.js
@@ -38,7 +38,50 @@ const FAKER_EXTENSIONS = /** @type {const} */ ({
     id8: () => hexString(8),
     comver: () =>
       `${Math.floor(Math.random() * 100)}.${Math.floor(Math.random() * 100)}`,
-    url: () => faker.internet.url(),
+  },
+  // Helpful references:
+  // - https://exiftool.org/TagNames/EXIF.html
+  // - https://www.media.mit.edu/pia/Research/deepview/exif.html
+  exif: {
+    // Local YYYY:MM:DD HH:MM:SS (i.e. should NOT be converted to UTC)
+    dateTime: () => {
+      const d = new Date(faker.date.past({ years: 1, refDate: Date.now() }))
+
+      const year = `${d.getFullYear()}`
+      const month = `${d.getMonth()}`.padStart(2, '0')
+      const date = `${d.getDate()}`.padStart(2, '0')
+
+      const hour = `${d.getHours()}`.padStart(2, '0')
+      const minutes = `${d.getMinutes()}`.padStart(2, '0')
+      const seconds = `${d.getSeconds()}`.padStart(2, '0')
+
+      return `${year}:${month}:${date} ${hour}:${minutes}:${seconds}`
+    },
+    // Helpful references
+    // - https://exiftool.org/TagNames/GPS.html
+    // - https://www.opanda.com/en/pe/help/gps.html#GPSTimeStamp
+    gps: {
+      // UTC-adjusted YYYY:MM:DD
+      dateStamp: () => {
+        const d = new Date(faker.date.past({ years: 1, refDate: Date.now() }))
+
+        const year = `${d.getUTCFullYear()}`
+        const month = `${d.getUTCMonth() + 1}`.padStart(2, '0')
+        const date = `${d.getUTCDate()}`.padStart(2, '0')
+
+        return `${year}:${month}:${date}`
+      },
+      // UTC-adjusted HH:MM:SS
+      timeStamp: () => {
+        const d = new Date(faker.date.past({ years: 1, refDate: Date.now() }))
+
+        const hour = `${d.getUTCHours()}`.padStart(2, '0')
+        const minutes = `${d.getUTCMinutes()}`.padStart(2, '0')
+        const seconds = `${d.getUTCSeconds()}`
+
+        return `${hour}:${minutes}:${seconds}`
+      },
+    },
   },
 })
 
@@ -73,7 +116,7 @@ function createFakerSchema(schema) {
     case 'DeviceInfo': {
       mutateWithFakerProperty(
         s.properties.selfHostedServerDetails.properties.baseUrl,
-        'mapeo.url',
+        'internet.url',
       )
       return s
     }
@@ -94,18 +137,46 @@ function createFakerSchema(schema) {
       mutateWithFakerProperty(s.properties.lon, 'location.longitude')
       mutateWithFakerProperty(s.properties.lat, 'location.latitude')
 
-      mutateWithFakerProperty(
-        s.properties.attachments.items.properties.driveDiscoveryId,
-        'mapeo.id',
-      )
-      mutateWithFakerProperty(
-        s.properties.attachments.items.properties.hash,
-        'mapeo.id',
-      )
-      mutateWithFakerProperty(
-        s.properties.attachments.items.properties.name,
-        'mapeo.id8',
-      )
+      // Attachments
+      for (const attachmentDef of s.definitions.attachment.oneOf) {
+        mutateWithFakerProperty(
+          attachmentDef.properties.driveDiscoveryId,
+          'mapeo.id',
+        )
+        mutateWithFakerProperty(attachmentDef.properties.hash, 'mapeo.id')
+        mutateWithFakerProperty(attachmentDef.properties.name, 'mapeo.id8')
+        mutateWithFakerProperty(
+          attachmentDef.properties.driveDiscoveryId,
+          'mapeo.id',
+        )
+        mutateWithFakerProperty(attachmentDef.properties.hash, 'mapeo.id')
+        mutateWithFakerProperty(attachmentDef.properties.name, 'mapeo.id8')
+
+        // TODO: Can fake more of the fields
+        if ('photoExif' in attachmentDef.properties) {
+          mutateWithFakerProperty(
+            attachmentDef.properties.photoExif.properties.DateTime,
+            'exif.dateTime',
+          )
+
+          mutateWithFakerProperty(
+            attachmentDef.properties.photoExif.properties.GPSLatitude,
+            'location.latitude',
+          )
+          mutateWithFakerProperty(
+            attachmentDef.properties.photoExif.properties.GPSLongitude,
+            'location.longitude',
+          )
+          mutateWithFakerProperty(
+            attachmentDef.properties.photoExif.properties.GPSTimeStamp,
+            'exif.gps.timeStamp',
+          )
+          mutateWithFakerProperty(
+            attachmentDef.properties.photoExif.properties.GPSDateStamp,
+            'exif.gps.dateStamp',
+          )
+        }
+      }
 
       mutateWithFakerProperty(
         s.properties.presetRef.properties.docId,
@@ -180,12 +251,23 @@ function createFakerSchema(schema) {
 }
 
 /**
- * @template {keyof typeof FAKER_EXTENSIONS} TCustomExtensionNamespace
- * @template {keyof (typeof FAKER_EXTENSIONS)[keyof typeof FAKER_EXTENSIONS]} TCustomExtensionField
- * @template {`${TCustomExtensionNamespace}.${TCustomExtensionField}`} TCustomExtensionId
- * @template {`location.${Extract<keyof import("@faker-js/faker").LocationModule, 'latitude' | 'longitude'>}`} TLocationFakerId
+ * Derives a union of all keys of an object, including nested objects. Each level of nesting is separated with a period (`.`).
+ * https://alexop.dev/posts/typescript-extract-all-keys-nested-objects/
+ *
+ * @template T
+ * @typedef {T extends object ? { [K in keyof T & string]: | K | (T[K] extends object ? `${K}.${ExtractKeys<T[K]>}` : never) }[keyof T & string] : never} ExtractKeys
+ */
+
+/**
+ * Derives valid Faker IDs that can be used with `json-schema-faker`.
+ *
+ * @template T
+ * @typedef {Extract<ExtractKeys<T>, `${string}.${string}`>} FakerId
+ */
+
+/**
  * @param {object} property
- * @param {TCustomExtensionId | TLocationFakerId} fakerId
+ * @param {FakerId<typeof FAKER_EXTENSIONS> | FakerId<import("@faker-js/faker").Faker>} fakerId
  */
 function mutateWithFakerProperty(property, fakerId) {
   // @ts-expect-error

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "list-mapeo-schemas": "bin/list-mapeo-schemas.js"
       },
       "devDependencies": {
-        "@comapeo/schema": "^1.5.0",
+        "@comapeo/schema": "1.6.0",
         "@tsconfig/node20": "^20.1.2",
         "@types/node": "^20.9.1",
         "eslint": "^8.53.0",
@@ -30,7 +30,7 @@
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
-        "@comapeo/schema": "^1.4.1"
+        "@comapeo/schema": "^1.6.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@comapeo/schema": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.5.0.tgz",
-      "integrity": "sha512-MIT9BSo34ffUKn6kZuBf10Xs3/7FZ2tVwXLi+Oi5DiOuTEI1r03DAI9XzGTqU2FsnPkza+dc5h6aaBB/ZuOsrA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.6.0.tgz",
+      "integrity": "sha512-Lk36pwUkGt/mEsOSEGWKSjUC+FWSu+qFJ4Cv0NpKRHF8+bORGBuVOsbmvnEiiZu0tTWncInBSBO0LoSEdseG8g==",
       "dev": true,
       "dependencies": {
         "@comapeo/geometry": "^1.1.1",
@@ -2259,9 +2259,9 @@
       }
     },
     "@comapeo/schema": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.5.0.tgz",
-      "integrity": "sha512-MIT9BSo34ffUKn6kZuBf10Xs3/7FZ2tVwXLi+Oi5DiOuTEI1r03DAI9XzGTqU2FsnPkza+dc5h6aaBB/ZuOsrA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.6.0.tgz",
+      "integrity": "sha512-Lk36pwUkGt/mEsOSEGWKSjUC+FWSu+qFJ4Cv0NpKRHF8+bORGBuVOsbmvnEiiZu0tTWncInBSBO0LoSEdseG8g==",
       "dev": true,
       "requires": {
         "@comapeo/geometry": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "type-fest": "^4.29.1"
   },
   "devDependencies": {
-    "@comapeo/schema": "^1.5.0",
+    "@comapeo/schema": "1.6.0",
     "@tsconfig/node20": "^20.1.2",
     "@types/node": "^20.9.1",
     "eslint": "^8.53.0",
@@ -48,7 +48,7 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@comapeo/schema": "^1.4.1"
+    "@comapeo/schema": "^1.6.0"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
Fixes #44 

1.6.0 actually introduces breaking changes to the internal implementation of this module. Also does some cleanup of type-related utilities to improve writing experience.

Did not do an exhaustive faking of the EXIF fields that the updated schema introduces. Open to doing more of it if desired.