### PR TITLE
feat!: update @comapeo/schema to 1.7.0

### DIFF
--- a/lib/faker.js
+++ b/lib/faker.js
@@ -39,50 +39,6 @@ const FAKER_EXTENSIONS = /** @type {const} */ ({
     comver: () =>
       `${Math.floor(Math.random() * 100)}.${Math.floor(Math.random() * 100)}`,
   },
-  // Helpful references:
-  // - https://exiftool.org/TagNames/EXIF.html
-  // - https://www.media.mit.edu/pia/Research/deepview/exif.html
-  exif: {
-    // Local YYYY:MM:DD HH:MM:SS (i.e. should NOT be converted to UTC)
-    dateTime: () => {
-      const d = new Date(faker.date.past({ years: 1, refDate: Date.now() }))
-
-      const year = `${d.getFullYear()}`
-      const month = `${d.getMonth()}`.padStart(2, '0')
-      const date = `${d.getDate()}`.padStart(2, '0')
-
-      const hour = `${d.getHours()}`.padStart(2, '0')
-      const minutes = `${d.getMinutes()}`.padStart(2, '0')
-      const seconds = `${d.getSeconds()}`.padStart(2, '0')
-
-      return `${year}:${month}:${date} ${hour}:${minutes}:${seconds}`
-    },
-    // Helpful references
-    // - https://exiftool.org/TagNames/GPS.html
-    // - https://www.opanda.com/en/pe/help/gps.html#GPSTimeStamp
-    gps: {
-      // UTC-adjusted YYYY:MM:DD
-      dateStamp: () => {
-        const d = new Date(faker.date.past({ years: 1, refDate: Date.now() }))
-
-        const year = `${d.getUTCFullYear()}`
-        const month = `${d.getUTCMonth() + 1}`.padStart(2, '0')
-        const date = `${d.getUTCDate()}`.padStart(2, '0')
-
-        return `${year}:${month}:${date}`
-      },
-      // UTC-adjusted HH:MM:SS
-      timeStamp: () => {
-        const d = new Date(faker.date.past({ years: 1, refDate: Date.now() }))
-
-        const hour = `${d.getUTCHours()}`.padStart(2, '0')
-        const minutes = `${d.getUTCMinutes()}`.padStart(2, '0')
-        const seconds = `${d.getUTCSeconds()}`
-
-        return `${hour}:${minutes}:${seconds}`
-      },
-    },
-  },
 })
 
 JSONSchemaFaker.extend('faker', () => {
@@ -149,31 +105,6 @@ function createFakerSchema(schema) {
         )
         mutateWithFakerProperty(attachmentDef.properties.hash, 'mapeo.id')
         mutateWithFakerProperty(attachmentDef.properties.name, 'mapeo.id8')
-
-        // TODO: Can fake more of the fields
-        if ('photoExif' in attachmentDef.properties) {
-          mutateWithFakerProperty(
-            attachmentDef.properties.photoExif.properties.DateTime,
-            'exif.dateTime',
-          )
-
-          mutateWithFakerProperty(
-            attachmentDef.properties.photoExif.properties.GPSLatitude,
-            'location.latitude',
-          )
-          mutateWithFakerProperty(
-            attachmentDef.properties.photoExif.properties.GPSLongitude,
-            'location.longitude',
-          )
-          mutateWithFakerProperty(
-            attachmentDef.properties.photoExif.properties.GPSTimeStamp,
-            'exif.gps.timeStamp',
-          )
-          mutateWithFakerProperty(
-            attachmentDef.properties.photoExif.properties.GPSDateStamp,
-            'exif.gps.dateStamp',
-          )
-        }
       }
 
       mutateWithFakerProperty(

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "list-mapeo-schemas": "bin/list-mapeo-schemas.js"
       },
       "devDependencies": {
-        "@comapeo/schema": "1.6.0",
+        "@comapeo/schema": "1.7.0",
         "@eslint/compat": "^1.2.9",
         "@eslint/js": "^9.26.0",
         "@types/node": "^18.19.100",
@@ -32,7 +32,7 @@
         "typescript": "^5.8.3"
       },
       "peerDependencies": {
-        "@comapeo/schema": "^1.6.0"
+        "@comapeo/schema": "^1.7.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -54,9 +54,9 @@
       }
     },
     "node_modules/@comapeo/schema": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.6.0.tgz",
-      "integrity": "sha512-Lk36pwUkGt/mEsOSEGWKSjUC+FWSu+qFJ4Cv0NpKRHF8+bORGBuVOsbmvnEiiZu0tTWncInBSBO0LoSEdseG8g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.7.0.tgz",
+      "integrity": "sha512-xsu2meZTLeVh7MNy0v/WDz4FPdkr2uwA3gHLvjzf8RsfNh5N/dzzmtbj92EIjLBECQ+YQ1ZRmabhbxnTgEZ7sA==",
       "dev": true,
       "dependencies": {
         "@comapeo/geometry": "^1.1.1",
@@ -3435,9 +3435,9 @@
       }
     },
     "@comapeo/schema": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.6.0.tgz",
-      "integrity": "sha512-Lk36pwUkGt/mEsOSEGWKSjUC+FWSu+qFJ4Cv0NpKRHF8+bORGBuVOsbmvnEiiZu0tTWncInBSBO0LoSEdseG8g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.7.0.tgz",
+      "integrity": "sha512-xsu2meZTLeVh7MNy0v/WDz4FPdkr2uwA3gHLvjzf8RsfNh5N/dzzmtbj92EIjLBECQ+YQ1ZRmabhbxnTgEZ7sA==",
       "dev": true,
       "requires": {
         "@comapeo/geometry": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -36,13 +36,16 @@
     "test:types": "tsc",
     "test": "npm-run-all --aggregate-output --print-label --parallel test:*"
   },
+  "peerDependencies": {
+    "@comapeo/schema": "^1.7.0"
+  },
   "dependencies": {
     "@faker-js/faker": "^9.7.0",
     "dereference-json-schema": "^0.2.1",
     "json-schema-faker": "^0.5.9"
   },
   "devDependencies": {
-    "@comapeo/schema": "1.6.0",
+    "@comapeo/schema": "1.7.0",
     "@eslint/compat": "^1.2.9",
     "@eslint/js": "^9.26.0",
     "@types/node": "^18.19.100",
@@ -54,9 +57,6 @@
     "prettier": "^3.5.3",
     "rimraf": "^5.0.10",
     "typescript": "^5.8.3"
-  },
-  "peerDependencies": {
-    "@comapeo/schema": "^1.6.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Similar in nature to #43 . Schema introduces some new fields and removes some fields that were introduced in 1.6.0. To avoid needing to account for changes across versions, seems more convenient to bump our minimum dep of schema to 1.7.0.