### PR TITLE
feat!: add support for @comapeo/schema@2

### DIFF
--- a/lib/faker.js
+++ b/lib/faker.js
@@ -160,6 +160,15 @@ function createFakerSchema(schema) {
         s.properties.observationRefs.items.properties.versionId,
         'mapeo.versionId',
       )
+      mutateWithFakerProperty(
+        s.properties.presetRef.properties.docId,
+        'mapeo.id',
+      )
+      mutateWithFakerProperty(
+        s.properties.presetRef.properties.versionId,
+        'mapeo.versionId',
+      )
+
       return s
     }
     case 'translation': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "list-mapeo-schemas": "bin/list-mapeo-schemas.js"
       },
       "devDependencies": {
-        "@comapeo/schema": "1.7.0",
+        "@comapeo/schema": "2.0.0",
         "@eslint/compat": "^1.2.9",
         "@eslint/js": "^9.26.0",
         "@types/node": "^18.19.100",
@@ -32,7 +32,7 @@
         "typescript": "^5.8.3"
       },
       "peerDependencies": {
-        "@comapeo/schema": "^1.7.0"
+        "@comapeo/schema": "^2.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -54,9 +54,9 @@
       }
     },
     "node_modules/@comapeo/schema": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.7.0.tgz",
-      "integrity": "sha512-xsu2meZTLeVh7MNy0v/WDz4FPdkr2uwA3gHLvjzf8RsfNh5N/dzzmtbj92EIjLBECQ+YQ1ZRmabhbxnTgEZ7sA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-2.0.0.tgz",
+      "integrity": "sha512-vAQhZPSd5tMe/F94X6GZC+3Np5psblitjmhdFp5qZm/xYE9anywwcdOIYIGu7A1RdA2KF7qi438g7YRvPcKHGg==",
       "dev": true,
       "dependencies": {
         "@comapeo/geometry": "^1.1.1",
@@ -3435,9 +3435,9 @@
       }
     },
     "@comapeo/schema": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-1.7.0.tgz",
-      "integrity": "sha512-xsu2meZTLeVh7MNy0v/WDz4FPdkr2uwA3gHLvjzf8RsfNh5N/dzzmtbj92EIjLBECQ+YQ1ZRmabhbxnTgEZ7sA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@comapeo/schema/-/schema-2.0.0.tgz",
+      "integrity": "sha512-vAQhZPSd5tMe/F94X6GZC+3Np5psblitjmhdFp5qZm/xYE9anywwcdOIYIGu7A1RdA2KF7qi438g7YRvPcKHGg==",
       "dev": true,
       "requires": {
         "@comapeo/geometry": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test": "npm-run-all --aggregate-output --print-label --parallel test:*"
   },
   "peerDependencies": {
-    "@comapeo/schema": "^1.7.0"
+    "@comapeo/schema": "^2.0.0"
   },
   "dependencies": {
     "@faker-js/faker": "^9.7.0",
@@ -45,7 +45,7 @@
     "json-schema-faker": "^0.5.9"
   },
   "devDependencies": {
-    "@comapeo/schema": "1.7.0",
+    "@comapeo/schema": "2.0.0",
     "@eslint/compat": "^1.2.9",
     "@eslint/js": "^9.26.0",
     "@types/node": "^18.19.100",


### PR DESCRIPTION
Updates requirement for `@comapeo/schema` to v2, which introduced the following changes:

- adding a required `external` field to observation attachment
- adding an optional `presetRef` field to track

Constitutes a breaking change as a result.